### PR TITLE
Add newer Node.js versions for prebuilt binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
 		"predeploy": "npm run safe-docs",
 		"build-binaries": "npm run build-binaries-node && npm run build-binaries-electron",
 		"build-binaries-node": "run-script-os",
-		"build-binaries-node:win32": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -t 10.17.0 -t 12.11.0 -t 13.0.0 -t 14.0.0 --verbose -u %GITHUB_TOKEN%",
-		"build-binaries-node:darwin:linux": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -t 10.17.0 -t 12.11.0 -t 13.0.0 -t 14.0.0 --verbose -u $GITHUB_TOKEN",
+		"build-binaries-node:win32": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -t 10.17.0 -t 12.11.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 --verbose -u %GITHUB_TOKEN%",
+		"build-binaries-node:darwin:linux": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -t 10.17.0 -t 12.11.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 --verbose -u $GITHUB_TOKEN",
 		"build-binaries-electron": "run-script-os",
-		"build-binaries-electron:win32": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -r electron -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 --verbose -u %GITHUB_TOKEN%",
-		"build-binaries-electron:darwin:linux": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -r electron -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 --verbose -u $GITHUB_TOKEN"
+		"build-binaries-electron:win32": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -r electron -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 --verbose -u %GITHUB_TOKEN%",
+		"build-binaries-electron:darwin:linux": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -r electron -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 --verbose -u $GITHUB_TOKEN"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Audify is behind 2 major version releases for Node, both in "classic" Node and electron-node, which can impact project which relies on those. This simple patch should add those newer versions to the batch of binaries that are built for each releases.