### PR TITLE
allow passing 0 frameSize to openstream(), return actual frameSize used

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -270,7 +270,7 @@ export declare class RtAudio {
     frameOutputCallback: (() => void) | null,
     flags?: RtAudioStreamFlags,
     errorCallback?: ((type: RtAudioErrorType, msg: string) => void) | null
-  ): void;
+  ): number;
 
   /**
    * A function that closes a stream and frees any associated stream memory.

--- a/index.d.ts
+++ b/index.d.ts
@@ -247,12 +247,12 @@ export declare class RtAudio {
   constructor(api?: RtAudioApi);
 
   /**
-   * A public function for opening a stream with the specified parameters.
+   * A public function for opening a stream with the specified parameters. Returns the actual frameSize used by the stream, useful if a frameSize of 0 is passed.
    * @param outputParameters Specifies output stream parameters to use when opening a stream. For input-only streams, this argument should be null.
    * @param inputParameters Specifies input stream parameters to use when opening a stream. For output-only streams, this argument should be null.
    * @param format An RtAudio.Format specifying the desired sample data format.
    * @param sampleRate The desired sample rate (sample frames per second).
-   * @param frameSize The amount of samples per frame.
+   * @param frameSize The amount of samples per frame. Can be 0 for some APIs, in which case the lowest allowable value is determined; this is necessary for the ASIO & Jack APIs where the user can set an overriding global buffer size for their device.
    * @param streamName A stream name (currently used only in Jack).
    * @param inputCallback A callback that is called when a new input signal is available. Should be null for output-only streams.
    * @param frameOutputCallback A callback that is called when a frame is finished playing in the output device.

--- a/src/rt_audio.cpp
+++ b/src/rt_audio.cpp
@@ -265,7 +265,7 @@ Napi::Value RtAudioWrap::openStream(const Napi::CallbackInfo &info) {
     throw Napi::Error::New(info.Env(), ex.what());
   }
 
-  // Save frame size
+  // Save frame size after openStream() has been called in case frameSize was overridden or 0 for default
   _frameSize = frameSize;
 
   // Lock the threadsafe functions mutex

--- a/src/rt_audio.cpp
+++ b/src/rt_audio.cpp
@@ -174,7 +174,7 @@ Napi::Value RtAudioWrap::getDefaultOutputDevice(
   return Napi::Number::New(info.Env(), _rtAudio->getDefaultOutputDevice());
 }
 
-void RtAudioWrap::openStream(const Napi::CallbackInfo &info) {
+Napi::Value RtAudioWrap::openStream(const Napi::CallbackInfo &info) {
   RtAudio::StreamParameters outputParams =
       info[0].IsNull() || info[0].IsUndefined()
           ? RtAudio::StreamParameters()
@@ -226,9 +226,6 @@ void RtAudioWrap::openStream(const Napi::CallbackInfo &info) {
     _frameOutputTsfn.Release();
   }
 
-  // Save frame size
-  _frameSize = frameSize;
-
   // Save input and output channels
   _inputChannels = inputParams.nChannels;
   _outputChannels = outputParams.nChannels;
@@ -268,6 +265,9 @@ void RtAudioWrap::openStream(const Napi::CallbackInfo &info) {
     throw Napi::Error::New(info.Env(), ex.what());
   }
 
+  // Save frame size
+  _frameSize = frameSize;
+
   // Lock the threadsafe functions mutex
   tsfnLock.lock();
 
@@ -286,6 +286,7 @@ void RtAudioWrap::openStream(const Napi::CallbackInfo &info) {
         info.Env(), frameOutputCallback, "frameOutputCallback", 0, 1,
         [this](Napi::Env) {});
   }
+  return Napi::Number::New(info.Env(), _frameSize);
 }
 
 void RtAudioWrap::closeStream(const Napi::CallbackInfo &info) {

--- a/src/rt_audio.h
+++ b/src/rt_audio.h
@@ -17,7 +17,7 @@ class RtAudioWrap : public Napi::ObjectWrap<RtAudioWrap> {
   Napi::Value getDefaultInputDevice(const Napi::CallbackInfo& info);
   Napi::Value getDefaultOutputDevice(const Napi::CallbackInfo& info);
 
-  void openStream(const Napi::CallbackInfo& info);
+  Napi::Value openStream(const Napi::CallbackInfo& info);
   void closeStream(const Napi::CallbackInfo& info);
   Napi::Value isStreamOpen(const Napi::CallbackInfo& info);
 


### PR DESCRIPTION
This aims to fix #18 by delaying storing the `frameSize` pointer value until after the stream is instantiated with `_rtAudio->openStream()` that way if rtAudio is left to choose a default/best value by passing a `frameSize` of 0, the resulting updated value is used in all subsequent calculations by audify. Additionally `rtAudioInstance.openStream()` now returns the actual `frameSize` used so that value is no longer a mystery to the audify user.

Tested successfully working with Windows ASIO on several devices. This should also fix similar issues with Jack but I don't have a setup to test that on. Note that not all rtAudio-supported APIs work with setting `frameSize` to 0, a quick test with WASAPI did not work properly.

My c++/Napi skills are barely-existent so apologies in advance if anything here is awful, please let me know if this is a terrible way to go about solving this problem 😅 