### PR TITLE
fix: bump prebuild versions to include v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install audify
 ```
 
 ***Most regular installs will support prebuilds that are built with each release.***
-***The prebuilds are for Node v12.11.x+, v13.x.x, v14.x.x, v15.x.x, v16.x.x, v17.x.x and Electron v8.x.x, v9.x.x, v10.x.x, v11.x.x, v12.x.x., v13.x.x., v14.x.x, v15.x.x, v16.x.x.***
+***The prebuilds are for Node v12.11.x+, v13.x.x, v14.x.x, v15.x.x, v16.x.x, v17.x.x, v18.x.x and Electron v8.x.x, v9.x.x, v10.x.x, v11.x.x, v12.x.x., v13.x.x., v14.x.x, v15.x.x, v16.x.x., v17.x.x, v18.x.x***
 
 #### Requirements for source build
 

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
 		"predeploy": "npm run safe-docs",
 		"build-binaries": "npm run build-binaries-node && npm run build-binaries-electron",
 		"build-binaries-node": "run-script-os",
-		"build-binaries-node:win32": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -t 12.11.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.0 --verbose -u %GITHUB_TOKEN%",
-		"build-binaries-node:darwin:linux": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -t 12.11.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.0 --verbose -u $GITHUB_TOKEN",
+		"build-binaries-node:win32": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -t 12.11.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.0 -t 18.0.0 --verbose -u %GITHUB_TOKEN%",
+		"build-binaries-node:darwin:linux": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -t 12.11.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.0 -t 18.0.0 --verbose -u $GITHUB_TOKEN",
 		"build-binaries-electron": "run-script-os",
-		"build-binaries-electron:win32": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -r electron -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 --verbose -u %GITHUB_TOKEN%",
-		"build-binaries-electron:darwin:linux": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -r electron -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 --verbose -u $GITHUB_TOKEN"
+		"build-binaries-electron:win32": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -r electron -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.0 -t 18.0.0 --verbose -u %GITHUB_TOKEN%",
+		"build-binaries-electron:darwin:linux": "prebuild --backend cmake-js --include-regex \"^.*\\.(node|dylib|dll|so(\\.[0-9])?)$\" -r electron -t 8.0.0 -t 9.0.0 -t 10.0.0 -t 11.0.0 -t 12.0.0 -t 13.0.0 -t 14.0.0 -t 15.0.0 -t 16.0.0 -t 17.0.0 -t 18.0.0 --verbose -u $GITHUB_TOKEN"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Provide prebuild versions for newer node and electron