### PR TITLE
bugfix: restore support for older macOS versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 
-# We force clang to generate code that should be compatible with macOS 10.7+
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.7" CACHE STRING "Minimum OS X deployment version")
+# We force clang to generate code that should be compatible with macOS 10.9+ as libc++ is supported on 10.9+
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
 
 project(audify)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
+
+# We force clang to generate code that should be compatible with macOS 10.7+
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.7" CACHE STRING "Minimum OS X deployment version")
+
 project(audify)
 
 IF (WIN32)


### PR DESCRIPTION
This change forces clang to generate code (and imports) that are compatible with macOS 10.9+.
We force macOS 10.9 as libc++ is supported from macOS 10.9.

This is used to resolve #44.